### PR TITLE
Add Shortcut commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/LearnWeb3DAO/lw3-cli#readme",
   "dependencies": {
+    "arg": "^5.0.1",
     "chalk": "^4.1.0",
     "clear": "^0.1.0",
     "esm": "^3.2.25",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,15 +1,16 @@
 import inquirer from "inquirer";
-import { textSync } from "figlet";
 const chalk = require("chalk");
 const clear = require("clear");
+import {getWelcomeMessage, getCLIInstructions} from './helpers'
 import lw3Generator from "./cli/lw3Generator";
 import {
   installHardhat,
   getHardhatDataInputs,
-  createNextApp,
-  generateFrontendFiles,
+  installNext,
+  generateNextFiles,
 } from "./generators";
 const fs = require("fs");
+import arg from 'arg';
 /**
  * selectGeneratorType is going to prompt user
  * to select one out of 3 options:
@@ -26,7 +27,44 @@ const fs = require("fs");
  * This option is going to generate whatever token standard you want to implement
  * and whatever functions you want to override in your contract
  */
-async function selectGeneratorType() {
+
+ async function parseArgumentsIntoOptions(rawArgs) {
+  const args = arg(
+    {
+      '--i:hardhat':Boolean,
+      '--g:hardhat':Boolean,
+      '--i:next':Boolean,
+      '--g:next':Boolean,
+      '--help':Boolean
+    },
+    {
+      argv: rawArgs.slice(2),
+    }
+  );
+  return {
+    installHardhat: args['--i:hardhat'] || false,
+    generateHardhat: args['--g:hardhat'] || false,
+    installNext: args['--i:next'] || false,
+    generateNext:args['--g:next'] || false,
+    help:args['--help'] || false
+  };
+}
+
+async function selectGeneratorType(options) {
+  clear()
+  getWelcomeMessage()
+  if(options.installHardhat){
+    installHardhat();
+  }else if(options.generateHardhat){
+    getHardhatDataInputs()
+  }else if(options.installNext){
+    installNext()
+  }else if(options.generateNext){
+    generateNextFiles()
+  }else if(options.help){
+    getCLIInstructions()
+  }else{
+
   const options = [];
   options.push({
     type: "list",
@@ -34,7 +72,7 @@ async function selectGeneratorType() {
     message: "select generator type: ",
     choices: [
       chalk.yellow("LearnWeb3"),
-      chalk.greenBright("Install Hardhat"),
+      chalk.greenBright("Install Hardhat along with essential dependencies"),
       chalk.blueBright("Generate Hardhat common files"),
       chalk.greenBright("Create Next.js app"),
       chalk.blueBright("Generate Next.js app common files"),
@@ -46,7 +84,9 @@ async function selectGeneratorType() {
   // generating track levels boilerplate
   if (answers.option == chalk.yellow("LearnWeb3")) {
     lw3Generator();
-  } else if (answers.option == chalk.greenBright("Install Hardhat")) {
+  } else if (
+    answers.option == chalk.greenBright("Install Hardhat along with essential dependencies"))
+    {
     installHardhat();
   } else if (
     answers.option == chalk.blueBright("Generate Hardhat common files")
@@ -59,10 +99,10 @@ async function selectGeneratorType() {
           )
         );
   } else if (answers.option == chalk.greenBright("Create Next.js app")) {
-    createNextApp();
+    installNext();
   } else {
     fs.existsSync("pages")
-      ? generateFrontendFiles()
+      ? generateNextFiles()
       : console.log(
           chalk.red(
             "Next.js directory is not found!\nPlease, switch to a directory where Next.js is installed!"
@@ -70,9 +110,9 @@ async function selectGeneratorType() {
         );
   }
 }
+}
 
-export async function cli() {
-  clear();
-  console.log(chalk.blue(textSync("LW3-CLI", { horizontalLayout: "full" })));
-  await selectGeneratorType();
+export async function cli(args) {
+  let options = await parseArgumentsIntoOptions(args);
+  await selectGeneratorType(options);
 }

--- a/src/generators/frontend/generateNextFiles.js
+++ b/src/generators/frontend/generateNextFiles.js
@@ -13,7 +13,7 @@ registerHelpers(Handlebars);
  * @param {*} contractName - The name of the contract, will be used when generating constants and won't prompt the user if specified
  */
 
-const generateFrontendFiles = async (verbose, contractName) => {
+const generateNextFiles = async (verbose, contractName) => {
   const { contract } =
     contractName ||
     (await inquirer.prompt([
@@ -71,4 +71,4 @@ const generateFrontendFiles = async (verbose, contractName) => {
   }
 };
 
-export default generateFrontendFiles;
+export default generateNextFiles;

--- a/src/generators/frontend/installNext.js
+++ b/src/generators/frontend/installNext.js
@@ -13,7 +13,7 @@ registerHelpers(Handlebars);
  * @returns {string} The folder in which the Next app was generated
  */
 
-const createNextApp = async (verbose) => {
+const installNext = async (verbose) => {
   const { nextAppFolder } = await inquirer.prompt([
     {
       name: "nextAppFolder",
@@ -45,4 +45,4 @@ const createNextApp = async (verbose) => {
   return nextAppFolder;
 };
 
-export default createNextApp;
+export default installNext;

--- a/src/generators/index.js
+++ b/src/generators/index.js
@@ -1,4 +1,4 @@
 export { default as installHardhat} from "./backend/installHardhat";
 export { default as getHardhatDataInputs } from './backend/getHardhatDataInputs';
-export { default as createNextApp } from "./frontend/createNextApp";
-export { default as generateFrontendFiles } from "./frontend/generateFrontendFiles";
+export { default as installNext } from "./frontend/installNext";
+export { default as generateNextFiles } from "./frontend/generateNextFiles";

--- a/src/generators/lw3/whitelist_dapp.js
+++ b/src/generators/lw3/whitelist_dapp.js
@@ -1,6 +1,6 @@
 import { runInstructions } from "../../helpers";
 import { installHardhat } from "../";
-import { createNextApp } from "../";
+import { installNext } from "../";
 import generateHardhatFiles from "../backend/generateHardhatFiles";
 import inquirer from "inquirer";
 
@@ -24,7 +24,7 @@ export default {
       "Whitelist",
       false
     );
-    const nextFolder = await createNextApp(false);
+    const nextFolder = await installNext(false);
     const instructions = [
       `mkdir ${nextFolder}/constants`,
       `echo "export const abi = YOUR_ABI;\nexport const WHITELIST_CONTRACT_ADDRESS = 'YOUR_WHITELIST_CONTRACT_ADDRESS'" >> ${nextFolder}/constants/index.js`,

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -1,4 +1,6 @@
 import { TRACKS } from "../constants/lw3";
+import { textSync } from "figlet";
+const chalk = require("chalk");
 
 export const getProjectsFromTrack = (trackName) => {
   return TRACKS.filter((track) => track.name == trackName)[0].projects;
@@ -20,4 +22,21 @@ export const toPascalCase = (value) =>{
       ($1, $2, $3) => `${$2.toUpperCase() + $3.toLowerCase()}`
     )
     .replace(new RegExp(/\w/), s => s.toUpperCase());
+}
+
+export const getWelcomeMessage = () =>{
+  console.log(chalk.blue(textSync("LW3-CLI", { horizontalLayout: "full" })));
+}
+
+export const getCLIInstructions = () =>{
+  console.log(
+    `
+    lw3-cli\t\t Show up the whole options of the CLI
+    lw3-cli --i:hardhat\t Install hardhat and the essential dependencies
+    lw3-cli --g:hardhat\t Generate the hardhat common files
+    lw3-cli --i:next\t Install next.js
+    lw3-cli --g:hardhat\t Generate the next.js common files
+    lw3-cli --help\t Show up the cli instructions
+    `
+  )
 }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -6,4 +6,9 @@ instead of import {registerHelpers} from "../helpers/handlebarsHelpers"
 */
 export { registerHelpers } from "./handlebarsHelpers";
 export { runInstructions } from "./runInstructions";
-export { getProjectGenerator, getProjectsFromTrack } from "./helpers";
+export {
+getProjectGenerator,
+getProjectsFromTrack,
+getWelcomeMessage,
+getCLIInstructions
+} from "./helpers";


### PR DESCRIPTION
This is the **third time** that I am going to explain whatever changes I have made previously.

- I separated the installation and generation process in order to **we cant install hardhat and generate hardhat files with one command**. Actually, hardhat won't let node CLI initiate the hardhat project by running **npx hardhat**.
- However, Next.js installation and generation process is possible to run by one command. But, I separated that someone can use it partially. suppose a user has installed next.js, he/she only needs to generate common files. If join this process on one command that is useless.

The new changes that I have made:
- The shortcut command is added for installing hardhat dependencies
- The shortcut command is added for generating common hardhat files
- The shortcut command is added for installing nextjs
- The shortcut command is added for generating frontend common files
- The shortcut command is added for showing instructions on how to use CLI

If you want to go with your vision, please go.
I started this project to make the life of our community members easier, I have to complete it.
At least I will stay loyal to our community and my slef.